### PR TITLE
Revert "feat: add env values for editor-article-store"

### DIFF
--- a/helm/libero-editor/templates/deployment-article-store.yaml
+++ b/helm/libero-editor/templates/deployment-article-store.yaml
@@ -36,29 +36,3 @@ spec:
           readinessProbe:
             tcpSocket:
               port: http
-          env:
-            - name: MONGO_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.database.secret | quote }}
-                  key: url
-            - name: MONGO_DB_NAME
-              value: {{ .Values.database.name | quote }}
-            - name: AWS_REGION
-              value: {{ .Values.aws.region | quote }}
-            - name: AWS_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.secret | quote }}
-                  key: key
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.secret | quote }}
-                  key: secret
-            - name: AWS_BUCKET_INPUT_EVENT_QUEUE_URL
-              value: {{ .Values.aws.sqsUrl | quote }}
-            - name: AWS_ENDPOINT
-              value: "s3.{{ .Values.aws.region | quote }}.amazonaws.com"
-            - name: AWS_EDITOR_BUCKET
-              value: {{ .Values.aws.bucket | quote }}

--- a/helm/libero-editor/values.yaml
+++ b/helm/libero-editor/values.yaml
@@ -24,15 +24,3 @@ articleStore:
     pullPolicy: Always
   port: 8080
   replicaCount: 1
-
-database:
-  # database.secret -- name of a secret with 'url' entries
-  secret: libero-editor--database-secret
-  name: 'editor'
-
-aws:
-  region: ''
-  # aws.secret -- name of a secret with 'key' and 'secret' entries
-  secret: libero-editor--aws-secret
-  sqsUrl: ''
-  bucket: 'prod-elife-editor'


### PR DESCRIPTION
Reverts elifesciences/libero-editor-formula#3


Seems to have broken flux-test linting so lets revert till we remove from flux-test and move to flux-cluster